### PR TITLE
azuread-api for å hente arrangør

### DIFF
--- a/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorControllerServiceUser.kt
+++ b/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorControllerServiceUser.kt
@@ -1,0 +1,21 @@
+package no.nav.arrangor.arrangor
+
+import no.nav.arrangor.arrangor.model.ArrangorMedOverordnetArrangor
+import no.nav.arrangor.utils.Issuer
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@ProtectedWithClaims(issuer = Issuer.AZURE_AD)
+@RequestMapping("/api/service/arrangor")
+class ArrangorControllerServiceUser(
+	private val arrangorService: ArrangorService
+) {
+	@GetMapping("/organisasjonsnummer/{orgnummer}")
+	fun getArrangor(@PathVariable("orgnummer") orgnummer: String): ArrangorMedOverordnetArrangor {
+		return arrangorService.getArrangorMedOverordnetArrangor(orgnummer)
+	}
+}

--- a/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorService.kt
+++ b/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorService.kt
@@ -1,6 +1,7 @@
 package no.nav.arrangor.arrangor
 
 import no.nav.arrangor.MetricsService
+import no.nav.arrangor.arrangor.model.ArrangorMedOverordnetArrangor
 import no.nav.arrangor.client.enhetsregister.EnhetsregisterClient
 import no.nav.arrangor.client.enhetsregister.Virksomhet
 import no.nav.arrangor.client.enhetsregister.defaultVirksomhet
@@ -34,6 +35,23 @@ class ArrangorService(
 			?: leggTilOppdaterArrangor(orgNr)
 		)
 		.let { it.toDomain(deltakerlisteRepository.getDeltakerlisterForArrangor(it.id)) }
+
+	fun getArrangorMedOverordnetArrangor(orgNr: String): ArrangorMedOverordnetArrangor {
+		val arrangor = arrangorRepository.get(orgNr)
+			?: leggTilOppdaterArrangor(orgNr)
+		val overordnetArrangor = arrangor.overordnetArrangorId?.let {
+			get(it)
+		}
+		return ArrangorMedOverordnetArrangor(
+			id = arrangor.id,
+			navn = arrangor.navn,
+			organisasjonsnummer = arrangor.organisasjonsnummer,
+			overordnetArrangorId = arrangor.overordnetArrangorId,
+			overordnetArrangorNavn = overordnetArrangor?.navn,
+			overordnetArrangorOrgnummer = overordnetArrangor?.organisasjonsnummer,
+			deltakerlister = deltakerlisteRepository.getDeltakerlisterForArrangor(arrangor.id)
+		)
+	}
 
 	fun addDeltakerlister(arrangorId: UUID, deltakerlisteIds: Set<UUID>) =
 		deltakerlisteRepository.addUpdateDeltakerlister(arrangorId, deltakerlisteIds)

--- a/src/main/kotlin/no/nav/arrangor/arrangor/model/ArrangorMedOverordnetArrangor.kt
+++ b/src/main/kotlin/no/nav/arrangor/arrangor/model/ArrangorMedOverordnetArrangor.kt
@@ -1,0 +1,13 @@
+package no.nav.arrangor.arrangor.model
+
+import java.util.UUID
+
+data class ArrangorMedOverordnetArrangor(
+	val id: UUID,
+	val navn: String,
+	val organisasjonsnummer: String,
+	val overordnetArrangorId: UUID?,
+	val overordnetArrangorNavn: String?,
+	val overordnetArrangorOrgnummer: String?,
+	val deltakerlister: Set<UUID>
+)

--- a/src/test/kotlin/no/nav/arrangor/arrangor/ArrangorControllerServiceUserTest.kt
+++ b/src/test/kotlin/no/nav/arrangor/arrangor/ArrangorControllerServiceUserTest.kt
@@ -1,0 +1,82 @@
+package no.nav.arrangor.arrangor
+
+import io.kotest.matchers.shouldBe
+import no.nav.arrangor.IntegrationTest
+import no.nav.arrangor.arrangor.model.ArrangorMedOverordnetArrangor
+import no.nav.arrangor.testutils.DbTestData
+import no.nav.arrangor.testutils.DbTestDataUtils
+import no.nav.arrangor.utils.JsonUtils
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import javax.sql.DataSource
+
+class ArrangorControllerServiceUserTest : IntegrationTest() {
+	@Autowired
+	private lateinit var datasource: DataSource
+
+	private lateinit var db: DbTestData
+
+	@BeforeEach
+	fun setUp() {
+		db = DbTestData(NamedParameterJdbcTemplate(datasource))
+	}
+
+	@AfterEach
+	fun tearDown() {
+		DbTestDataUtils.cleanDatabase(datasource)
+		resetMockServers()
+	}
+
+	@Test
+	fun `getArrangor - ikke gyldig token - unauthorized`() {
+		val response = sendRequest(
+			method = "GET",
+			path = "/api/service/arrangor/organisasjonsnummer/12345"
+		)
+
+		response.code shouldBe 401
+	}
+
+	@Test
+	fun `getArrangor - autentisert, arrangor har ikke overordnet arrangor - returnerer arrangor`() {
+		val orgnummer = "12345"
+		db.insertArrangor(navn = "Navn", organisasjonsnummer = orgnummer, overordnetArrangorId = null)
+
+		val response = sendRequest(
+			method = "GET",
+			path = "/api/service/arrangor/organisasjonsnummer/$orgnummer",
+			headers = mapOf("Authorization" to "Bearer ${getAzureAdToken()}")
+		)
+
+		response.code shouldBe 200
+		val arrangor = JsonUtils.fromJson<ArrangorMedOverordnetArrangor>(response.body!!.string())
+		arrangor.organisasjonsnummer shouldBe orgnummer
+		arrangor.navn shouldBe "Navn"
+		arrangor.overordnetArrangorId shouldBe null
+	}
+
+	@Test
+	fun `getArrangor - autentisert, arrangor har overordnet arrangor - returnerer arrangor`() {
+		val orgnummerOverordnetArrangor = "98765"
+		val overordnetArrangor = db.insertArrangor(navn = "Overordnet", organisasjonsnummer = orgnummerOverordnetArrangor, overordnetArrangorId = null)
+		val orgnummer = "12345"
+		db.insertArrangor(navn = "Navn", organisasjonsnummer = orgnummer, overordnetArrangorId = overordnetArrangor.id)
+
+		val response = sendRequest(
+			method = "GET",
+			path = "/api/service/arrangor/organisasjonsnummer/$orgnummer",
+			headers = mapOf("Authorization" to "Bearer ${getAzureAdToken()}")
+		)
+
+		response.code shouldBe 200
+		val arrangor = JsonUtils.fromJson<ArrangorMedOverordnetArrangor>(response.body!!.string())
+		arrangor.organisasjonsnummer shouldBe orgnummer
+		arrangor.navn shouldBe "Navn"
+		arrangor.overordnetArrangorId shouldBe overordnetArrangor.id
+		arrangor.overordnetArrangorNavn shouldBe "Overordnet"
+		arrangor.overordnetArrangorOrgnummer shouldBe orgnummerOverordnetArrangor
+	}
+}


### PR DESCRIPTION
Trenger endepunkt som amt-tiltak kan bruke med azuread, og for å unngå å måtte slå opp to ganger for å hente overordnet arrangør. 