### PR TITLE
Fjerne jobber

### DIFF
--- a/src/main/kotlin/no/nav/arrangor/ansatt/repositories/KoordinatorDeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/arrangor/ansatt/repositories/KoordinatorDeltakerlisteRepository.kt
@@ -53,6 +53,19 @@ class KoordinatorDeltakerlisteRepository(
 		}
 	}
 
+	fun deaktiverKoordinatorDeltakerliste(ansattId: UUID, arrangorId: UUID) {
+		template.update(
+			"""
+				UPDATE koordinator_deltakerliste
+				SET gyldig_til = CURRENT_TIMESTAMP
+				WHERE ansatt_id = :ansatt_id
+				  AND deltakerliste_id IN (SELECT id FROM deltakerliste WHERE arrangor_id = :arrangor_id)
+				  AND gyldig_til IS NULL
+			""".trimIndent(),
+			sqlParameters("ansatt_id" to ansattId, "arrangor_id" to arrangorId)
+		)
+	}
+
 	fun getAktive(ansattId: UUID): List<KoordinatorDeltakerlisteDbo> {
 		val sql = """
 			SELECT koordinator_deltakerliste.*,

--- a/src/main/kotlin/no/nav/arrangor/ansatt/repositories/RolleRepository.kt
+++ b/src/main/kotlin/no/nav/arrangor/ansatt/repositories/RolleRepository.kt
@@ -62,8 +62,8 @@ class RolleRepository(
 		val sql = """
 		SELECT ansatt_rolle.*,
 		       arrangor.organisasjonsnummer as organisasjonsnummer
-		FROM ansatt_rolle 
-		left join arrangor on ansatt_rolle.arrangor_id = arrangor.id 
+		FROM ansatt_rolle
+		left join arrangor on ansatt_rolle.arrangor_id = arrangor.id
 		WHERE ansatt_id = :ansatt_id
 		AND gyldig_til is NULL
 		""".trimIndent()
@@ -74,18 +74,6 @@ class RolleRepository(
 			rowMapper
 		)
 	}
-
-	fun getAll(ansattId: UUID): List<RolleDbo> = template.query(
-		"""
-		SELECT ansatt_rolle.*,
-		       arrangor.organisasjonsnummer as organisasjonsnummer
-		FROM ansatt_rolle 
-		left join arrangor on ansatt_rolle.arrangor_id = arrangor.id 
-		WHERE ansatt_id = :ansatt_id
-		""".trimIndent(),
-		sqlParameters("ansatt_id" to ansattId),
-		rowMapper
-	)
 
 	data class RolleInput(
 		val ansattId: UUID,

--- a/src/main/kotlin/no/nav/arrangor/ansatt/repositories/VeilederDeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/arrangor/ansatt/repositories/VeilederDeltakerRepository.kt
@@ -57,6 +57,19 @@ class VeilederDeltakerRepository(
 		}
 	}
 
+	fun deaktiver(ansattId: UUID, arrangorId: UUID) {
+		template.update(
+			"""
+				UPDATE veileder_deltaker
+				SET gyldig_til = CURRENT_TIMESTAMP
+				WHERE ansatt_id = :ansatt_id
+				  AND arrangor_id = :arrangor_id
+				  AND gyldig_til IS NULL
+			""".trimIndent(),
+			sqlParameters("ansatt_id" to ansattId, "arrangor_id" to arrangorId)
+		)
+	}
+
 	fun getAktive(ansattId: UUID): List<VeilederDeltakerDbo> {
 		return template.query(
 			"SELECT * FROM veileder_deltaker WHERE ansatt_id = :ansatt_id AND gyldig_til IS NULL",

--- a/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorService.kt
+++ b/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorService.kt
@@ -63,8 +63,8 @@ class ArrangorService(
 		)
 	}
 
-	fun addDeltakerlister(arrangorId: UUID, deltakerlisteIds: Set<UUID>) =
-		deltakerlisteRepository.addUpdateDeltakerlister(arrangorId, deltakerlisteIds)
+	fun addDeltakerliste(arrangorId: UUID, deltakerlisteId: UUID) =
+		deltakerlisteRepository.upsertDeltakerliste(arrangorId, deltakerlisteId)
 
 	private fun upsertArrangor(orgNr: String): ArrangorRepository.ArrangorDbo {
 		val arrangor = arrangorRepository.get(orgNr)

--- a/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorService.kt
+++ b/src/main/kotlin/no/nav/arrangor/arrangor/ArrangorService.kt
@@ -9,7 +9,6 @@ import no.nav.arrangor.domain.Arrangor
 import no.nav.arrangor.ingest.PublishService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
 import java.util.UUID
 
 /*
@@ -66,11 +65,6 @@ class ArrangorService(
 
 	fun addDeltakerlister(arrangorId: UUID, deltakerlisteIds: Set<UUID>) =
 		deltakerlisteRepository.addUpdateDeltakerlister(arrangorId, deltakerlisteIds)
-
-	fun oppdaterArrangorer(limit: Int = 50, synchronizedBefore: LocalDateTime = LocalDateTime.now().minusDays(1)) =
-		arrangorRepository.getToSynchronize(limit, synchronizedBefore)
-			.map { upsertArrangor(it.organisasjonsnummer) }
-			.also { logger.info("Oppdaterte ${it.size} arrangører") }
 
 	private fun upsertArrangor(orgNr: String): ArrangorRepository.ArrangorDbo {
 		val arrangor = arrangorRepository.get(orgNr)

--- a/src/main/kotlin/no/nav/arrangor/configuration/Jobs.kt
+++ b/src/main/kotlin/no/nav/arrangor/configuration/Jobs.kt
@@ -14,10 +14,10 @@ class Jobs(
 	private val ansattService: AnsattService
 ) {
 	@Scheduled(cron = "@hourly")
-	@SchedulerLock(name = "oppdater_ansatte", lockAtMostFor = "120m")
-	fun updateAnsatte() {
+	@SchedulerLock(name = "oppdater_roller", lockAtMostFor = "120m")
+	fun updateRoller() {
 		if (leaderElection.isLeader()) {
-			JobRunner.run("Oppdater ansatte") { ansattService.oppdaterAnsatte() }
+			JobRunner.run("Oppdater roller") { ansattService.oppdaterAnsattesRoller() }
 		}
 	}
 }

--- a/src/main/kotlin/no/nav/arrangor/configuration/Jobs.kt
+++ b/src/main/kotlin/no/nav/arrangor/configuration/Jobs.kt
@@ -2,7 +2,6 @@ package no.nav.arrangor.configuration
 
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import no.nav.arrangor.ansatt.AnsattService
-import no.nav.arrangor.arrangor.ArrangorService
 import no.nav.common.job.JobRunner
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -12,17 +11,8 @@ import org.springframework.scheduling.annotation.Scheduled
 @Configuration
 class Jobs(
 	private val leaderElection: LeaderElection,
-	private val arrangorService: ArrangorService,
 	private val ansattService: AnsattService
 ) {
-	@Scheduled(cron = "@hourly")
-	@SchedulerLock(name = "oppdater_arrangører", lockAtMostFor = "120m")
-	fun updateArrangorer() {
-		if (leaderElection.isLeader()) {
-			JobRunner.run("Oppdater arrangører") { arrangorService.oppdaterArrangorer() }
-		}
-	}
-
 	@Scheduled(cron = "@hourly")
 	@SchedulerLock(name = "oppdater_ansatte", lockAtMostFor = "120m")
 	fun updateAnsatte() {

--- a/src/main/kotlin/no/nav/arrangor/deltakerliste/DeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/arrangor/deltakerliste/DeltakerlisteRepository.kt
@@ -10,7 +10,7 @@ class DeltakerlisteRepository(
 	private val template: NamedParameterJdbcTemplate
 ) {
 
-	fun addUpdateDeltakerlister(arrangorId: UUID, deltakerlisteIds: Set<UUID>) {
+	fun upsertDeltakerliste(arrangorId: UUID, deltakerlisteId: UUID) {
 		val sql = """
 		INSERT INTO deltakerliste(id, arrangor_id)
 		    VALUES (:id, :arrangor_id)
@@ -18,9 +18,9 @@ class DeltakerlisteRepository(
 									   modified_at = current_timestamp
 		""".trimIndent()
 
-		template.batchUpdate(
+		template.update(
 			sql,
-			deltakerlisteIds.map { sqlParameters("id" to it, "arrangor_id" to arrangorId) }.toTypedArray()
+			sqlParameters("id" to deltakerlisteId, "arrangor_id" to arrangorId)
 		)
 	}
 

--- a/src/main/kotlin/no/nav/arrangor/ingest/IngestService.kt
+++ b/src/main/kotlin/no/nav/arrangor/ingest/IngestService.kt
@@ -124,7 +124,7 @@ class IngestService(
 		}
 		val arrangor = arrangorService.get(gjennomforing.virksomhetsnummer)
 			?: throw IllegalStateException("Har mottatt gjennomføring med ukjent arrangør. Orgnummer ${gjennomforing.virksomhetsnummer}, gjennomføring ${gjennomforing.id}")
-		arrangorService.addDeltakerlister(arrangor.id, setOf(gjennomforing.id))
+		arrangorService.addDeltakerliste(arrangor.id, gjennomforing.id)
 		logger.info("Konsumerte gjennomføring med id ${gjennomforing.id}")
 		metricsService.incConsumedGjennomforing()
 	}

--- a/src/test/kotlin/no/nav/arrangor/ansatt/AnsattControllerTest.kt
+++ b/src/test/kotlin/no/nav/arrangor/ansatt/AnsattControllerTest.kt
@@ -127,7 +127,7 @@ class AnsattControllerTest : IntegrationTest() {
 		}
 
 		@Test
-		fun `getAnsattByPersonident - om lastSynchronized over 1 time - oppdater Ansatt`() {
+		fun `getAnsattByPersonident - om lastSynchronized over 1 time - oppdater ansattroller`() {
 			val arrangorOne = db.insertArrangor()
 			val arrangorTwo = db.insertArrangor()
 			val arrangorThree = db.insertArrangor()
@@ -156,12 +156,9 @@ class AnsattControllerTest : IntegrationTest() {
 				)
 			)
 
-			mockPersonServer.setPerson(personident, personId, "Test2", "Mellom", "Testersen2")
 			val nyAnsatt = getAnsatt(personident)
 
-			nyAnsatt.personalia.navn.fornavn shouldBe "Test2"
-			nyAnsatt.personalia.navn.mellomnavn shouldBe "Mellom"
-			nyAnsatt.personalia.navn.etternavn shouldBe "Testersen2"
+			nyAnsatt.personalia.navn.fornavn shouldBe "Test"
 
 			nyAnsatt.arrangorer.map { it.arrangorId } shouldContainExactly listOf(arrangorTwo.id, arrangorThree.id)
 

--- a/src/test/kotlin/no/nav/arrangor/arrangor/ArrangorControllerTest.kt
+++ b/src/test/kotlin/no/nav/arrangor/arrangor/ArrangorControllerTest.kt
@@ -1,20 +1,15 @@
 package no.nav.arrangor.arrangor
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import no.nav.arrangor.IntegrationTest
 import no.nav.arrangor.client.enhetsregister.Virksomhet
 import no.nav.arrangor.domain.Arrangor
 import no.nav.arrangor.utils.JsonUtils
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDateTime
 import java.util.UUID
 
 class ArrangorControllerTest : IntegrationTest() {
-
-	@Autowired
-	lateinit var arrangorService: ArrangorService
 
 	@Autowired
 	lateinit var arrangorRepository: ArrangorRepository
@@ -53,39 +48,6 @@ class ArrangorControllerTest : IntegrationTest() {
 
 		response.organisasjonsnummer shouldBe orgNr
 		response.overordnetArrangorId shouldBe null
-	}
-
-	@Test
-	fun `get - Finnes fra for - oppdaterer`() {
-		val input = ArrangorRepository.ArrangorDbo(
-			navn = "originaltNavn",
-			organisasjonsnummer = "123",
-			overordnetArrangorId = null
-		)
-
-		arrangorRepository.insertOrUpdate(input)
-
-		mockAmtEnhetsregiserServer.addVirksomhet(
-			Virksomhet(
-				organisasjonsnummer = input.organisasjonsnummer,
-				navn = "nyttNavn",
-				overordnetEnhetOrganisasjonsnummer = "456",
-				overordnetEnhetNavn = "overordnetArrangor"
-			)
-		)
-
-		arrangorService.oppdaterArrangorer(synchronizedBefore = LocalDateTime.now().plusMinutes(1))
-
-		val response = sendRequest(
-			method = "GET",
-			path = "/api/arrangor/organisasjonsnummer/${input.organisasjonsnummer}",
-			headers = mapOf("Authorization" to "Bearer ${getTokenxToken(fnr = "12345678910")}")
-		)
-			.also { it.code shouldBe 200 }
-			.let { JsonUtils.fromJson<Arrangor>(it.body!!.string()) }
-
-		response.navn shouldBe "nyttNavn"
-		response.overordnetArrangorId shouldNotBe null
 	}
 
 	@Test


### PR DESCRIPTION
amt-arrangør bør heller oppdatere arrangørnavn ved å lytte på enhetsregister-topicen (det kan gjøres etter vi har prodsatt). Endringer på ansattes personopplysninger bør skje ved at vi lytter på topic som amt-person-service skriver til når denne er klar (det haster ikke siden vi uansett ikke har dette i dag). Jeg har derfor fjernet arrangør-jobben, og endret ansatt-jobben så vi kun oppdaterer roller fra altinn. 

I tillegg manglet det funksjonalitet som sørget for at vi også fjernet veileder-relasjon og deltakerlister som koordinator har lagt til hvis en rolle skal deaktiveres. 