### PR TITLE
Endre personident felt i request/response hos amt-person

### DIFF
--- a/src/main/kotlin/no/nav/arrangor/client/person/PersonClient.kt
+++ b/src/main/kotlin/no/nav/arrangor/client/person/PersonClient.kt
@@ -38,12 +38,12 @@ class PersonClient(
 	}
 
 	data class PersonRequest(
-		val personIdent: String
+		val personident: String
 	)
 
 	data class PersonResponse(
 		val id: UUID,
-		val personIdent: String,
+		val personident: String,
 		val fornavn: String,
 		val mellomnavn: String?,
 		val etternavn: String

--- a/src/test/kotlin/no/nav/arrangor/mock/MockPersonServer.kt
+++ b/src/test/kotlin/no/nav/arrangor/mock/MockPersonServer.kt
@@ -22,7 +22,7 @@ class MockPersonServer : MockHttpServer("amt-person") {
 					JsonUtils.toJson(
 						PersonClient.PersonResponse(
 							id = personId,
-							personIdent = personident,
+							personident = personident,
 							fornavn,
 							mellomnavn,
 							etternavn


### PR DESCRIPTION
`personIdent` feltet er deprecated og er erstattet av `personident`