### PR TITLE
Bump dependencies - 20250303084429

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ val tokenSupportVersion = "5.0.17"
 val arrowVersion = "2.0.1"
 val kotestVersion = "5.9.1"
 val testcontainersVersion = "1.20.5"
-val mockkVersion = "1.13.16"
+val mockkVersion = "1.13.17"
 val mockOauth2ServerVersion = "2.1.10"
 val ktlintVersion = "1.4.1"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 
     id("org.springframework.boot") version "3.4.3"
     id("io.spring.dependency-management") version "1.1.7"
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
+    id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.spring") version kotlinVersion
 }


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250303084429 branch:

- [Bump io.mockk:mockk from 1.13.16 to 1.13.17](https://github.com/navikt/amt-arrangor/pull/269)
- [Bump org.jlleitschuh.gradle.ktlint from 12.1.2 to 12.2.0](https://github.com/navikt/amt-arrangor/pull/268)
