### PR TITLE
Byttet ut 'management.endpoint.prometheus.enabled' som er deprikert

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,8 +10,7 @@ amt-person.scope=${AMT_PERSON_SCOPE}
 spring.main.banner-mode=off
 server.shutdown=graceful
 
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
+management.endpoint.prometheus.access=read_only
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.group.liveness.include=livenessState
 management.endpoints.web.base-path=/internal

--- a/src/test/kotlin/no/nav/arrangor/ActuatorTest.kt
+++ b/src/test/kotlin/no/nav/arrangor/ActuatorTest.kt
@@ -1,0 +1,61 @@
+package no.nav.arrangor
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.server.LocalManagementPort
+import org.springframework.http.HttpStatus
+import org.springframework.web.util.UriComponentsBuilder
+import kotlin.jvm.java
+
+class ActuatorTest(
+	@LocalManagementPort private val managementPort: Int,
+	private val restTemplate: TestRestTemplate,
+) : IntegrationTest() {
+	@ParameterizedTest(name = "{0} probe skal returnere OK og status = UP")
+	@ValueSource(strings = ["liveness", "readiness"])
+	fun probe_skal_returnere_OK_og_status_UP(probeName: String) {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/health/{probeName}")
+				.buildAndExpand(managementPort, probeName)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		assertSoftly(response) {
+			statusCode shouldBe HttpStatus.OK
+			body shouldBe "{\"status\":\"UP\"}"
+		}
+	}
+
+	@Test
+	fun `Prometheus-endepunktet skal returnere OK`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/prometheus")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		response.statusCode shouldBe HttpStatus.OK
+	}
+
+	@Test
+	fun `Metrics-endepunktet skal returnere NOT_FOUND`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/metrics")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		// GlobalExceptionHandler er konfigurert til å returnere INTERNAL_SERVER_ERROR f0r NOT_FOUND
+		response.statusCode shouldBe HttpStatus.INTERNAL_SERVER_ERROR
+	}
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,14 +1,3 @@
-spring.main.banner-mode=off
-server.shutdown=graceful
-
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
-management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.liveness.include=livenessState
-management.endpoints.web.base-path=/internal
-management.endpoints.web.exposure.include=prometheus,health
-management.prometheus.metrics.export.enabled=true
-
 spring.main.allow-bean-definition-overriding=true
 
 nais.env.azureAppClientId=test


### PR DESCRIPTION
- Byttet ut deprikert `management.endpoint.prometheus.enabled`  med `management.endpoint.prometheus.access`. [Spring-Boot-3.4-Configuration-Changelog](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Configuration-Changelog)
- Fjernet deprikert `management.endpoint.metrics.enabled=true` fordi denne ikke er med i `management.endpoints.web.exposure.include` og er dermed overflødig.
- Fjernet entries fra application-test.properties hvor nøkkel/verdi var lik som i application.properties.
- Lagt til tester for actuator-endepunktene
