### PR TITLE
Forenklet lesing av Timestamp fra database. Lagt til tester.

### DIFF
--- a/src/main/kotlin/no/nav/arrangor/ansatt/repository/AnsattRepository.kt
+++ b/src/main/kotlin/no/nav/arrangor/ansatt/repository/AnsattRepository.kt
@@ -1,8 +1,8 @@
 package no.nav.arrangor.ansatt.repository
 
 import no.nav.arrangor.utils.JsonUtils
-import no.nav.arrangor.utils.getZonedDateTime
 import no.nav.arrangor.utils.sqlParameters
+import no.nav.arrangor.utils.toSystemZoneLocalDateTime
 import org.postgresql.util.PGobject
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
@@ -25,8 +25,8 @@ class AnsattRepository(
 				mellomnavn = rs.getString("mellomnavn"),
 				etternavn = rs.getString("etternavn"),
 				arrangorer = JsonUtils.fromJson(rs.getString("arrangorer")),
-				modifiedAt = rs.getZonedDateTime("modified_at").toLocalDateTime(),
-				lastSynchronized = rs.getZonedDateTime("last_synchronized").toLocalDateTime(),
+				modifiedAt = rs.getTimestamp("modified_at").toSystemZoneLocalDateTime(),
+				lastSynchronized = rs.getTimestamp("last_synchronized").toSystemZoneLocalDateTime(),
 			)
 		}
 

--- a/src/main/kotlin/no/nav/arrangor/deltaker/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/arrangor/deltaker/DeltakerRepository.kt
@@ -3,8 +3,8 @@ package no.nav.arrangor.deltaker
 import no.nav.arrangor.kafka.model.Deltaker
 import no.nav.arrangor.kafka.model.DeltakerStatus
 import no.nav.arrangor.kafka.model.DeltakerStatusType
-import no.nav.arrangor.utils.getZonedDateTime
 import no.nav.arrangor.utils.sqlParameters
+import no.nav.arrangor.utils.toSystemZoneLocalDateTime
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
@@ -20,8 +20,8 @@ class DeltakerRepository(
 				id = UUID.fromString(rs.getString("id")),
 				status = DeltakerStatus(
 					type = DeltakerStatusType.valueOf(rs.getString("statustype")),
-					gyldigFra = rs.getZonedDateTime("gyldig_fra").toLocalDateTime(),
-					opprettetDato = rs.getZonedDateTime("opprettet_dato").toLocalDateTime(),
+					gyldigFra = rs.getTimestamp("gyldig_fra").toSystemZoneLocalDateTime(),
+					opprettetDato = rs.getTimestamp("opprettet_dato").toSystemZoneLocalDateTime(),
 				),
 			)
 		}

--- a/src/main/kotlin/no/nav/arrangor/utils/DatabaseUtils.kt
+++ b/src/main/kotlin/no/nav/arrangor/utils/DatabaseUtils.kt
@@ -2,18 +2,16 @@ package no.nav.arrangor.utils
 
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
 import java.sql.ResultSet
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
+import java.sql.Timestamp
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.UUID
 
 fun <V> sqlParameters(vararg pairs: Pair<String, V>): MapSqlParameterSource = MapSqlParameterSource().addValues(pairs.toMap())
 
 fun ResultSet.getNullableUUID(columnLabel: String): UUID? = this.getString(columnLabel)?.let { UUID.fromString(it) }
 
-fun ResultSet.getNullableZonedDateTime(columnLabel: String): ZonedDateTime? = this.getTimestamp(columnLabel)?.let {
-	ZonedDateTime.ofInstant(Instant.ofEpochMilli(it.time), ZoneOffset.systemDefault())
-}
-
-fun ResultSet.getZonedDateTime(columnLabel: String): ZonedDateTime = getNullableZonedDateTime(columnLabel)
-	?: throw IllegalStateException("Expected $columnLabel not to be null")
+fun Timestamp.toSystemZoneLocalDateTime(): LocalDateTime = this
+	.toInstant()
+	.atZone(ZoneId.systemDefault())
+	.toLocalDateTime()

--- a/src/test/kotlin/no/nav/arrangor/RepositoryTestBase.kt
+++ b/src/test/kotlin/no/nav/arrangor/RepositoryTestBase.kt
@@ -4,6 +4,7 @@ import no.nav.arrangor.ansatt.repository.AnsattRepository
 import no.nav.arrangor.arrangor.ArrangorRepository
 import no.nav.arrangor.database.DbTestDataUtils.cleanDatabase
 import no.nav.arrangor.database.TestDatabaseService
+import no.nav.arrangor.deltaker.DeltakerRepository
 import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureJdbc
@@ -18,7 +19,7 @@ import org.testcontainers.utility.DockerImageName
 import javax.sql.DataSource
 
 @ActiveProfiles("test")
-@SpringBootTest(classes = [AnsattRepository::class, ArrangorRepository::class, TestDatabaseService::class])
+@SpringBootTest(classes = [AnsattRepository::class, ArrangorRepository::class, DeltakerRepository::class, TestDatabaseService::class])
 @AutoConfigureJdbc
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 abstract class RepositoryTestBase {

--- a/src/test/kotlin/no/nav/arrangor/deltaker/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arrangor/deltaker/DeltakerRepositoryTest.kt
@@ -1,0 +1,77 @@
+package no.nav.arrangor.deltaker
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import no.nav.arrangor.RepositoryTestBase
+import no.nav.arrangor.kafka.model.Deltaker
+import no.nav.arrangor.kafka.model.DeltakerStatus
+import no.nav.arrangor.kafka.model.DeltakerStatusType
+import no.nav.arrangor.utils.shouldBeCloseTo
+import no.nav.arrangor.utils.shouldBeCloseToNow
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
+
+class DeltakerRepositoryTest(
+	private val deltakerRepository: DeltakerRepository,
+) : RepositoryTestBase() {
+	@Test
+	fun `insertOrUpdate skal lagre deltaker dersom den ikke finnes fra for`() {
+		deltakerRepository.insertOrUpdate(deltakerInTest)
+
+		val deltakerInDb = deltakerRepository.get(deltakerInTest.id)
+
+		assertSoftly(deltakerInDb.shouldNotBeNull()) {
+			id shouldBe deltakerInTest.id
+
+			assertSoftly(deltakerInDb.status) {
+				type shouldBe DeltakerStatusType.DELTAR
+				gyldigFra shouldBeCloseTo now.plusDays(1)
+				opprettetDato.shouldBeCloseToNow()
+			}
+		}
+	}
+
+	@Test
+	fun `insertOrUpdate skal oppdatere eksisterende deltaker dersom den finnes fra for`() {
+		deltakerRepository.insertOrUpdate(deltakerInTest)
+
+		val updatedDeltaker = deltakerInTest.copy(
+			status = DeltakerStatus(
+				type = DeltakerStatusType.IKKE_AKTUELL,
+				gyldigFra = now.plusDays(2),
+				opprettetDato = now.plusHours(1),
+			),
+		)
+
+		deltakerRepository.insertOrUpdate(updatedDeltaker)
+
+		val deltakerInDb = deltakerRepository.get(deltakerInTest.id)
+
+		assertSoftly(deltakerInDb.shouldNotBeNull()) {
+			id shouldBe deltakerInTest.id
+
+			assertSoftly(deltakerInDb.status) {
+				type shouldBe DeltakerStatusType.IKKE_AKTUELL
+				gyldigFra shouldBeCloseTo now.plusDays(2)
+				opprettetDato shouldBeCloseTo now.plusHours(1)
+			}
+		}
+	}
+
+	companion object {
+		private val now = LocalDateTime.now()
+
+		private val statusInTest = DeltakerStatus(
+			type = DeltakerStatusType.DELTAR,
+			gyldigFra = now.plusDays(1),
+			opprettetDato = now,
+		)
+
+		private val deltakerInTest = Deltaker(
+			id = UUID.randomUUID(),
+			status = statusInTest,
+		)
+	}
+}

--- a/src/test/kotlin/no/nav/arrangor/utils/DateTimeAssertions.kt
+++ b/src/test/kotlin/no/nav/arrangor/utils/DateTimeAssertions.kt
@@ -1,0 +1,19 @@
+package no.nav.arrangor.utils
+
+import io.kotest.matchers.date.shouldBeWithin
+import io.kotest.matchers.nulls.shouldNotBeNull
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+
+infix fun LocalDateTime.shouldBeCloseTo(expected: LocalDateTime?) {
+	expected.shouldNotBeNull()
+	this.shouldBeWithin(Duration.ofSeconds(10), expected)
+}
+
+fun LocalDateTime.shouldBeCloseToNow() = this.shouldBeWithin(Duration.ofSeconds(10), LocalDateTime.now())
+
+infix fun ZonedDateTime.shouldBeCloseTo(expected: ZonedDateTime?) {
+	expected.shouldNotBeNull()
+	this.shouldBeWithin(Duration.ofSeconds(10), expected)
+}


### PR DESCRIPTION
Tilsvarende kode finnes i en rekke repoer. Jeg har ikke lyktes med å fremprovosere feil i tester ved lesing av timestamp-kolonner med kun `.toLocalDateTime()`, det er derfor usikkert om omveien om instant er påkrevet. Det er testet med bl.a. 
```
rs.getTimestamp("last_synchronized").toLocalDateTime()
```
og det har fungert  både for timestamp-kolonner definert som `timestamp with time zone` og `timestamp` (uten `with time zone`).

Denne PRen handler kun om å forenkle eksisterende kode og sikre korrekt lesing av timestamp-kolonner vha. tester.

Følgende kode 
```
fun ResultSet.getNullableZonedDateTime(columnLabel: String): ZonedDateTime? = this.getTimestamp(columnLabel)?.let {
	ZonedDateTime.ofInstant(Instant.ofEpochMilli(it.time), ZoneOffset.systemDefault())
}

fun ResultSet.getZonedDateTime(columnLabel: String): ZonedDateTime = getNullableZonedDateTime(columnLabel)
	?: throw IllegalStateException("Expected $columnLabel not to be null")
```
er erstattet med 
```
fun Timestamp.toSystemZoneLocalDateTime(): LocalDateTime = this
	.toInstant()
	.atZone(ZoneId.systemDefault())
	.toLocalDateTime()
```

for å lese timestamp-felter med `timestamp with time zone`.

**Før**
```
lastSynchronized = rs.getZonedDateTime("last_synchronized").toLocalDateTime(),

```

**Etter**
```
lastSynchronized = rs.getTimestamp("last_synchronized").toSystemZoneLocalDateTime(),
```

Lagt til tester for `AnsattRepository` og `DeltakerRepository`.